### PR TITLE
checkpointing: Add finer grained checkpoints for SpeciesRax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,45 @@ To build the sources:
 
 See the wiki (https://github.com/BenoitMorel/GeneRax/wiki)
 
+### Running SpeciesRax with example data
+
+Download and extract the test datasets:
+
+```
+wget https://cme.h-its.org/exelixis/material/generax_data.tar.gz
+tar xzf generax_data.tar.gz
+```
+
+Prepare a families file (e.g. `families.txt`) listing gene trees and mappings:
+
+```
+[FAMILIES]
+- HBG284008_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG284008_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG284008_sim/mappings/mapping.link
+- HBG284199_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG284199_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG284199_sim/mappings/mapping.link
+```
+
+Run SpeciesRax to infer a species tree:
+
+```
+./build/bin/generax --families families.txt --species-tree MiniNJ --strategy SKIP --rec-model UndatedDTL --per-family-rates --prune-species-tree --si-strategy HYBRID --prefix output
+```
+
+### Checkpointing
+
+For long-running SpeciesRax analyses, enable checkpointing with the `--checkpoint` flag. This saves progress after each search iteration so the run can be resumed if interrupted:
+
+```
+./build/bin/generax --families families.txt --species-tree MiniNJ --strategy SKIP --rec-model UndatedDTL --per-family-rates --prune-species-tree --si-strategy HYBRID --prefix output --checkpoint
+```
+
+If the run is interrupted, simply re-run the same command. It will detect the checkpoint in the output directory and resume from where it left off.
+
+A checkpoint test script is provided in `tests/test_speciesrax_checkpoint.sh`. It requires the test data above and should be run from the repository root.
+
 ## Issues and questions
 
 For questions, issues or feedback, please post on our google group: https://groups.google.com/g/generaxusers

--- a/src/GeneRax/GeneRaxArguments.cpp
+++ b/src/GeneRax/GeneRaxArguments.cpp
@@ -48,6 +48,7 @@ GeneRaxArguments::GeneRaxArguments(int iargc, char * iargv[]):
   quartetSupport(false),
   quartetSupportAllQuartets(false),
   eqpicRadius(std::numeric_limits<int>::max()),
+  checkpoint(false),
   generateFakeAlignments(false)
 {
   if (argc == 1) {
@@ -170,6 +171,8 @@ void GeneRaxArguments::init() {
       quartetSupportAllQuartets = true; 
     } else if (arg == "--reconciliation-samples") {
       reconciliationSampleNumber = static_cast<unsigned int>(atoi(argv[++i]));
+    } else if (arg == "--checkpoint") {
+      checkpoint = true;
     } else if (arg == "--generate-fake-alignments") {
       generateFakeAlignments = true;
     } else {
@@ -249,6 +252,7 @@ void GeneRaxArguments::printHelp() {
   Logger::info << "--do-not-reconcile" << std::endl;
   Logger::info << "--reconciliation-samples <number of samples>" << std::endl;
   Logger::info << "--seed <seed>" << std::endl;
+  Logger::info << "--checkpoint" << std::endl;
   Logger::info << "Please find more information on the GeneRax github wiki" << std::endl;
   Logger::info << std::endl;
 
@@ -292,6 +296,7 @@ void GeneRaxArguments::printSummary() {
   Logger::info << "- Prune species tree mode: " << boolStr[pruneSpeciesTree] << std::endl;
   Logger::info << std::endl;
 
+  Logger::info << "- Checkpointing: " << boolStr[checkpoint] << std::endl;
   if (speciesStrategy != SpeciesSearchStrategy::SKIP) {
     Logger::info << "Species tree inference information:" << std::endl;
     Logger::info << "- Species tree Strategy: " << ArgumentsHelper::speciesStrategyToStr(speciesStrategy) << std::endl;

--- a/src/GeneRax/GeneRaxArguments.hpp
+++ b/src/GeneRax/GeneRaxArguments.hpp
@@ -64,6 +64,9 @@ public:
    bool quartetSupportAllQuartets;
    int eqpicRadius;
    
+   // checkpointing
+   bool checkpoint;
+
    // hacky stuff
    bool generateFakeAlignments;
 private:

--- a/src/GeneRax/GeneRaxCore.cpp
+++ b/src/GeneRax/GeneRaxCore.cpp
@@ -192,13 +192,14 @@ static void speciesTreeSearchAux(GeneRaxInstance &instance, int samples)
   searchParams.sprRadius = instance.args.speciesSPRRadius;
   searchParams.rootSmallRadius = instance.args.speciesSmallRootRadius;
   searchParams.rootBigRadius = instance.args.speciesBigRootRadius;
-  SpeciesTreeOptimizer speciesTreeOptimizer(instance.speciesTree, 
-      instance.currentFamilies, 
-      instance.getRecModelInfo(), 
-      startingRates, 
-      instance.args.userDTLRates, 
-      instance.args.outputPath, 
-      searchParams);
+  SpeciesTreeOptimizer speciesTreeOptimizer(instance.speciesTree,
+      instance.currentFamilies,
+      instance.getRecModelInfo(),
+      startingRates,
+      instance.args.userDTLRates,
+      instance.args.outputPath,
+      searchParams,
+      instance.args.checkpoint);
   if (instance.args.speciesSPRRadius > 0) {
     Logger::info << std::endl;
     Logger::timed << "Start optimizing the species tree with fixed gene trees (on " 

--- a/src/GeneRax/generax.cpp
+++ b/src/GeneRax/generax.cpp
@@ -4,8 +4,9 @@
 #include <parallelization/ParallelContext.hpp>
 #include <IO/Logger.hpp>
 #include <routines/SlavesMain.hpp>
-
-
+#include <util/Checkpoint.hpp>
+#include <IO/FileSystem.hpp>
+#include <util/Paths.hpp>
 
 
 int generax_main(int argc, char** argv, void* comm)
@@ -17,11 +18,56 @@ int generax_main(int argc, char** argv, void* comm)
   plop.assign(1, 1.0);
   GeneRaxInstance instance(argc, argv);
   GeneRaxCore::initInstance(instance);
-  GeneRaxCore::initRandomGeneTrees(instance);
-  GeneRaxCore::initSpeciesTree(instance);
+  Checkpoint checkpoint(instance.args.outputPath, instance.args.checkpoint);
+  bool resuming = checkpoint.isEnabled() && checkpoint.has("phase");
+  int completedPhase = resuming ? checkpoint.getInt("phase") : -1;
+  if (resuming) {
+    Logger::timed << "[Checkpoint] Resuming from phase " << completedPhase << std::endl;
+  }
+  if (completedPhase < 1) {
+    GeneRaxCore::initRandomGeneTrees(instance);
+    GeneRaxCore::initSpeciesTree(instance);
+    if (checkpoint.isEnabled()) {
+      // Save the starting species tree so we can fall back to it on
+      // resume when no iteration-level checkpoint exists yet
+      auto startingTree = Paths::getSpeciesTreeFile(
+          instance.args.outputPath, "checkpoint_starting_species_tree.newick");
+      FileSystem::copy(instance.speciesTree, startingTree, true);
+      checkpoint.save("phase", 1);
+    }
+  } else {
+    // Resuming: pick the right species tree depending on whether
+    // an iteration-level checkpoint exists
+    auto iterationTree = Paths::getSpeciesTreeFile(
+        instance.args.outputPath, "checkpoint_species_tree.newick");
+    auto startingTree = Paths::getSpeciesTreeFile(
+        instance.args.outputPath, "checkpoint_starting_species_tree.newick");
+    if (checkpoint.has("hybrid_iteration") && FileSystem::exists(iterationTree)) {
+      // Resume from the tree saved at the last completed search iteration
+      instance.speciesTree = iterationTree;
+      Logger::timed << "[Checkpoint] Loaded species tree from iteration checkpoint"
+        << std::endl;
+    } else if (FileSystem::exists(startingTree)) {
+      // No iteration checkpoint yet — restart search from the starting tree
+      instance.speciesTree = startingTree;
+      Logger::timed << "[Checkpoint] Loaded starting species tree from checkpoint"
+        << std::endl;
+    } else {
+      Logger::timed << "[Checkpoint] Warning: no checkpointed species tree found, reinitializing" << std::endl;
+      GeneRaxCore::initRandomGeneTrees(instance);
+      GeneRaxCore::initSpeciesTree(instance);
+    }
+  }
   GeneRaxCore::generateFakeAlignments(instance);
   GeneRaxCore::printStats(instance);
-  GeneRaxCore::speciesTreeSearch(instance);
+  if (completedPhase < 2) {
+    GeneRaxCore::speciesTreeSearch(instance);
+    if (checkpoint.isEnabled()) {
+      checkpoint.save("phase", 2);
+    }
+  } else {
+    Logger::timed << "[Checkpoint] Skipping species tree search (already completed)" << std::endl;
+  }
   GeneRaxCore::geneTreeJointSearch(instance);
   GeneRaxCore::reconcile(instance);
   GeneRaxCore::speciesTreeBLEstimation(instance);

--- a/tests/speciesrax_checkpoint_test/families_100.txt
+++ b/tests/speciesrax_checkpoint_test/families_100.txt
@@ -1,0 +1,301 @@
+[FAMILIES]
+- HBG284369_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG284369_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG284369_sim/mappings/mapping.link
+- HBG284523_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG284523_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG284523_sim/mappings/mapping.link
+- HBG284947_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG284947_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG284947_sim/mappings/mapping.link
+- HBG284990_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG284990_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG284990_sim/mappings/mapping.link
+- HBG285179_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG285179_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG285179_sim/mappings/mapping.link
+- HBG285270_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG285270_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG285270_sim/mappings/mapping.link
+- HBG285605_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG285605_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG285605_sim/mappings/mapping.link
+- HBG285698_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG285698_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG285698_sim/mappings/mapping.link
+- HBG285727_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG285727_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG285727_sim/mappings/mapping.link
+- HBG286075_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG286075_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG286075_sim/mappings/mapping.link
+- HBG286237_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG286237_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG286237_sim/mappings/mapping.link
+- HBG286341_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG286341_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG286341_sim/mappings/mapping.link
+- HBG286527_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG286527_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG286527_sim/mappings/mapping.link
+- HBG286573_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG286573_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG286573_sim/mappings/mapping.link
+- HBG287056_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG287056_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG287056_sim/mappings/mapping.link
+- HBG287136_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG287136_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG287136_sim/mappings/mapping.link
+- HBG289809_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG289809_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG289809_sim/mappings/mapping.link
+- HBG293864_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG293864_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG293864_sim/mappings/mapping.link
+- HBG294213_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG294213_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG294213_sim/mappings/mapping.link
+- HBG294308_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG294308_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG294308_sim/mappings/mapping.link
+- HBG299314_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG299314_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG299314_sim/mappings/mapping.link
+- HBG301263_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG301263_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG301263_sim/mappings/mapping.link
+- HBG302271_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG302271_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG302271_sim/mappings/mapping.link
+- HBG311214_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG311214_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG311214_sim/mappings/mapping.link
+- HBG313369_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG313369_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG313369_sim/mappings/mapping.link
+- HBG317982_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG317982_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG317982_sim/mappings/mapping.link
+- HBG329596_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG329596_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG329596_sim/mappings/mapping.link
+- HBG360398_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG360398_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG360398_sim/mappings/mapping.link
+- HBG362710_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG362710_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG362710_sim/mappings/mapping.link
+- HBG370454_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG370454_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG370454_sim/mappings/mapping.link
+- HBG400967_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG400967_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG400967_sim/mappings/mapping.link
+- HBG403839_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG403839_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG403839_sim/mappings/mapping.link
+- HBG405459_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG405459_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG405459_sim/mappings/mapping.link
+- HBG405561_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG405561_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG405561_sim/mappings/mapping.link
+- HBG409922_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG409922_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG409922_sim/mappings/mapping.link
+- HBG410188_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG410188_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG410188_sim/mappings/mapping.link
+- HBG437822_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG437822_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG437822_sim/mappings/mapping.link
+- HBG456486_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG456486_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG456486_sim/mappings/mapping.link
+- HBG476673_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG476673_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG476673_sim/mappings/mapping.link
+- HBG497643_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG497643_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG497643_sim/mappings/mapping.link
+- HBG500000_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG500000_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG500000_sim/mappings/mapping.link
+- HBG507255_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG507255_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG507255_sim/mappings/mapping.link
+- HBG507761_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG507761_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG507761_sim/mappings/mapping.link
+- HBG515603_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG515603_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG515603_sim/mappings/mapping.link
+- HBG518238_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG518238_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG518238_sim/mappings/mapping.link
+- HBG518924_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG518924_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG518924_sim/mappings/mapping.link
+- HBG527379_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG527379_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG527379_sim/mappings/mapping.link
+- HBG535236_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG535236_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG535236_sim/mappings/mapping.link
+- HBG537530_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG537530_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG537530_sim/mappings/mapping.link
+- HBG540956_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG540956_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG540956_sim/mappings/mapping.link
+- HBG555690_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG555690_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG555690_sim/mappings/mapping.link
+- HBG557189_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG557189_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG557189_sim/mappings/mapping.link
+- HBG561233_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG561233_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG561233_sim/mappings/mapping.link
+- HBG571744_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG571744_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG571744_sim/mappings/mapping.link
+- HBG577712_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG577712_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG577712_sim/mappings/mapping.link
+- HBG577902_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG577902_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG577902_sim/mappings/mapping.link
+- HBG580689_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG580689_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG580689_sim/mappings/mapping.link
+- HBG581077_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG581077_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG581077_sim/mappings/mapping.link
+- HBG583461_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG583461_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG583461_sim/mappings/mapping.link
+- HBG586587_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG586587_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG586587_sim/mappings/mapping.link
+- HBG592135_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG592135_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG592135_sim/mappings/mapping.link
+- HBG610809_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG610809_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG610809_sim/mappings/mapping.link
+- HBG616253_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG616253_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG616253_sim/mappings/mapping.link
+- HBG634430_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG634430_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG634430_sim/mappings/mapping.link
+- HBG634441_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG634441_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG634441_sim/mappings/mapping.link
+- HBG634538_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG634538_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG634538_sim/mappings/mapping.link
+- HBG635075_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG635075_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG635075_sim/mappings/mapping.link
+- HBG635089_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG635089_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG635089_sim/mappings/mapping.link
+- HBG635106_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG635106_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG635106_sim/mappings/mapping.link
+- HBG635225_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG635225_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG635225_sim/mappings/mapping.link
+- HBG635304_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG635304_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG635304_sim/mappings/mapping.link
+- HBG635320_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG635320_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG635320_sim/mappings/mapping.link
+- HBG635321_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG635321_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG635321_sim/mappings/mapping.link
+- HBG635631_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG635631_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG635631_sim/mappings/mapping.link
+- HBG636404_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG636404_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG636404_sim/mappings/mapping.link
+- HBG646290_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG646290_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG646290_sim/mappings/mapping.link
+- HBG646784_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG646784_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG646784_sim/mappings/mapping.link
+- HBG647131_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG647131_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG647131_sim/mappings/mapping.link
+- HBG648813_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG648813_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG648813_sim/mappings/mapping.link
+- HBG650065_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG650065_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG650065_sim/mappings/mapping.link
+- HBG664092_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG664092_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG664092_sim/mappings/mapping.link
+- HBG668356_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG668356_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG668356_sim/mappings/mapping.link
+- HBG669860_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG669860_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG669860_sim/mappings/mapping.link
+- HBG689426_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG689426_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG689426_sim/mappings/mapping.link
+- HBG691818_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG691818_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG691818_sim/mappings/mapping.link
+- HBG692398_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG692398_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG692398_sim/mappings/mapping.link
+- HBG695954_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG695954_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG695954_sim/mappings/mapping.link
+- HBG709628_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG709628_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG709628_sim/mappings/mapping.link
+- HBG710237_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG710237_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG710237_sim/mappings/mapping.link
+- HBG710503_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG710503_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG710503_sim/mappings/mapping.link
+- HBG710518_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG710518_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG710518_sim/mappings/mapping.link
+- HBG711150_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG711150_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG711150_sim/mappings/mapping.link
+- HBG713904_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG713904_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG713904_sim/mappings/mapping.link
+- HBG731751_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG731751_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG731751_sim/mappings/mapping.link
+- HBG734153_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG734153_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG734153_sim/mappings/mapping.link
+- HBG735169_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG735169_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG735169_sim/mappings/mapping.link
+- HBG738311_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG738311_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG738311_sim/mappings/mapping.link
+- HBG753256_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG753256_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG753256_sim/mappings/mapping.link
+- HBG754735_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG754735_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG754735_sim/mappings/mapping.link
+- HBG758551_sim
+starting_gene_tree = generax_data/cyano_simulated/families/HBG758551_sim/gene_trees/raxml-ng.LG+G+I.geneTree.newick
+mapping = generax_data/cyano_simulated/families/HBG758551_sim/mappings/mapping.link

--- a/tests/test_speciesrax_checkpoint.sh
+++ b/tests/test_speciesrax_checkpoint.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# Test script for SpeciesRax checkpointing
+# Uses 100 randomly selected families from cyano_simulated dataset
+#
+# Verifies that:
+# 1. A fresh run (no --checkpoint) produces identical results to an
+#    uninterrupted --checkpoint run
+# 2. An interrupted (phase-level) + resumed --checkpoint run produces
+#    identical results to a fresh run
+# 3. An interrupted (iteration-level) + resumed --checkpoint run
+#    completes successfully (result may differ slightly because the
+#    evaluator's internal state cannot be fully serialized)
+#
+# Usage: Run from the GeneRax repository root:
+#   bash tests/test_speciesrax_checkpoint.sh
+
+set -euo pipefail
+
+GENERAX=build/bin/generax
+DATADIR=generax_data/cyano_simulated
+TESTDIR=tests/speciesrax_checkpoint_test
+FAMILIES_FILE=$TESTDIR/families_100.txt
+
+if [ ! -f "$GENERAX" ]; then
+  echo "Error: Cannot find $GENERAX. Please build GeneRax first (./install.sh)."
+  exit 1
+fi
+
+if [ ! -d "$DATADIR" ]; then
+  echo "Error: Cannot find $DATADIR. Please download and extract the test data first:"
+  echo "  wget https://cme.h-its.org/exelixis/material/generax_data.tar.gz"
+  echo "  tar xzf generax_data.tar.gz"
+  exit 1
+fi
+
+# Create test directory
+mkdir -p "$TESTDIR"
+
+# Generate families file with 100 randomly selected families
+echo "Generating families file with 100 random families..."
+python3 -c "
+import os, random
+random.seed(42)
+families_dir = '$DATADIR/families'
+families = sorted(os.listdir(families_dir))
+selected = sorted(random.sample(families, 100))
+print('[FAMILIES]')
+for fam in selected:
+    gene_tree = os.path.join(families_dir, fam, 'gene_trees', 'raxml-ng.LG+G+I.geneTree.newick')
+    mapping = os.path.join(families_dir, fam, 'mappings', 'mapping.link')
+    if os.path.exists(gene_tree) and os.path.exists(mapping):
+        print(f'- {fam}')
+        print(f'starting_gene_tree = {gene_tree}')
+        print(f'mapping = {mapping}')
+" > "$FAMILIES_FILE"
+
+NUM_FAMILIES=$(grep -c "^- " "$FAMILIES_FILE")
+echo "Generated families file with $NUM_FAMILIES families"
+
+COMMON_ARGS="--families $FAMILIES_FILE --species-tree MiniNJ --strategy SKIP --rec-model UndatedDTL --per-family-rates --prune-species-tree --si-strategy HYBRID"
+
+# Clean up any previous test output
+rm -rf "$TESTDIR"/output_*
+
+FAILED=0
+
+echo ""
+echo "===== Test 1: Fresh run (no --checkpoint) ====="
+echo ""
+
+$GENERAX $COMMON_ARGS --prefix "$TESTDIR/output_fresh"
+
+echo ""
+echo "===== Test 2: Uninterrupted --checkpoint run ====="
+echo ""
+
+$GENERAX $COMMON_ARGS --prefix "$TESTDIR/output_checkpoint" --checkpoint
+
+# Compare fresh vs uninterrupted checkpoint (must be identical)
+echo ""
+echo "--- Comparing fresh vs uninterrupted checkpoint ---"
+if diff -q "$TESTDIR/output_fresh/species_trees/inferred_species_tree.newick" \
+           "$TESTDIR/output_checkpoint/species_trees/inferred_species_tree.newick" > /dev/null 2>&1; then
+  echo "PASS: Species trees identical"
+else
+  echo "FAIL: Species trees differ"
+  FAILED=1
+fi
+
+if diff -q "$TESTDIR/output_fresh/stats.txt" \
+           "$TESTDIR/output_checkpoint/stats.txt" > /dev/null 2>&1; then
+  echo "PASS: Stats identical"
+else
+  echo "FAIL: Stats differ"
+  FAILED=1
+fi
+
+echo ""
+echo "===== Test 3: Phase-level interrupt + resume ====="
+echo "(kill before iteration checkpoint is saved)"
+echo ""
+
+# 10 seconds is enough to save the starting species tree (phase 1)
+# but not enough to complete any search iteration
+timeout 10 $GENERAX $COMMON_ARGS --prefix "$TESTDIR/output_phase_resume" --checkpoint || true
+
+echo ""
+echo "Checkpoint state after interruption:"
+cat "$TESTDIR/output_phase_resume/checkpoint.txt" 2>/dev/null || echo "(no checkpoint file)"
+echo ""
+
+# Resume
+$GENERAX $COMMON_ARGS --prefix "$TESTDIR/output_phase_resume" --checkpoint
+
+echo ""
+echo "--- Comparing fresh vs phase-level resume ---"
+if diff -q "$TESTDIR/output_fresh/species_trees/inferred_species_tree.newick" \
+           "$TESTDIR/output_phase_resume/species_trees/inferred_species_tree.newick" > /dev/null 2>&1; then
+  echo "PASS: Species trees identical"
+else
+  echo "FAIL: Species trees differ"
+  FAILED=1
+fi
+
+if diff -q "$TESTDIR/output_fresh/stats.txt" \
+           "$TESTDIR/output_phase_resume/stats.txt" > /dev/null 2>&1; then
+  echo "PASS: Stats identical"
+else
+  echo "FAIL: Stats differ"
+  FAILED=1
+fi
+
+echo ""
+echo "===== Test 4: Iteration-level interrupt + resume ====="
+echo "(kill after at least one iteration checkpoint is saved)"
+echo ""
+
+# 25 seconds should be enough for 1-2 iteration checkpoints
+timeout 25 $GENERAX $COMMON_ARGS --prefix "$TESTDIR/output_iter_resume" --checkpoint || true
+
+echo ""
+echo "Checkpoint state after interruption:"
+cat "$TESTDIR/output_iter_resume/checkpoint.txt" 2>/dev/null || echo "(no checkpoint file)"
+echo ""
+
+if grep -q "hybrid_iteration" "$TESTDIR/output_iter_resume/checkpoint.txt" 2>/dev/null; then
+  echo "Iteration-level checkpoint found, resuming..."
+  $GENERAX $COMMON_ARGS --prefix "$TESTDIR/output_iter_resume" --checkpoint
+
+  echo ""
+  echo "--- Checking iteration-level resume ---"
+  if [ -f "$TESTDIR/output_iter_resume/species_trees/inferred_species_tree.newick" ]; then
+    echo "PASS: Completed successfully"
+  else
+    echo "FAIL: No output species tree"
+    FAILED=1
+  fi
+
+  if [ -f "$TESTDIR/output_iter_resume/stats.txt" ]; then
+    echo "PASS: Stats file exists"
+  else
+    echo "FAIL: No stats file"
+    FAILED=1
+  fi
+else
+  echo "NOTE: Iteration-level checkpoint was not reached (timing-dependent)."
+  echo "      Skipping iteration-level resume test."
+fi
+
+echo ""
+echo "===== Results ====="
+echo ""
+echo "Reconciliation likelihoods:"
+echo "  Fresh:                $(grep RecLL "$TESTDIR/output_fresh/stats.txt")"
+echo "  Checkpoint:           $(grep RecLL "$TESTDIR/output_checkpoint/stats.txt")"
+echo "  Phase-level resume:   $(grep RecLL "$TESTDIR/output_phase_resume/stats.txt")"
+if [ -f "$TESTDIR/output_iter_resume/stats.txt" ]; then
+  echo "  Iter-level resume:    $(grep RecLL "$TESTDIR/output_iter_resume/stats.txt")"
+fi
+
+# Clean up
+rm -rf "$TESTDIR"
+
+echo ""
+if [ $FAILED -eq 0 ]; then
+  echo "All tests PASSED!"
+  exit 0
+else
+  echo "Some tests FAILED!"
+  exit 1
+fi


### PR DESCRIPTION
Hi,

Thanks for this nice tool.

This branch adds more fine-grained checkpointing for SpeciesRax, which was taking more than our 48 hour HPC runtime maximum for larger trees. It was all generated by Claude, so this could just be a waste of everyone's time - apologies if so. However, it does pass the new test. A summary is below. 

Some of the changes are implemented in https://github.com/wwood/GeneRaxCore/tree/checkpointing in the submodule - not sure if it would be helpful to open another PR for that.

There's an argument that the checkpointing should be on by default from a UI standpoint since it is quite low overhead apparently.


  Checkpointing Implementation Summary 

  Files Modified

  GeneRax (main repo):
  - src/GeneRax/GeneRaxArguments.hpp/cpp — Added --checkpoint flag
  - src/GeneRax/generax.cpp — Phase-level checkpointing with species tree persistence; on resume, selects starting or iteration-level tree
  - src/GeneRax/GeneRaxCore.cpp — Passes checkpoint flag to SpeciesTreeOptimizer
  - README.md — SpeciesRax usage instructions + checkpointing docs

  GeneRaxCore (submodule):
  - src/util/Checkpoint.hpp — New key-value checkpoint class with full-precision double serialization
  - src/optimizers/SpeciesTreeOptimizer.hpp/cpp — Iteration-level checkpoint save/restore in HYBRID search loop

  New test:
  - tests/test_speciesrax_checkpoint.sh — Tests fresh, uninterrupted checkpoint, phase-level resume, and iteration-level resume

  Checkpointing Behavior

  1. Uninterrupted --checkpoint runs produce identical results to runs without --checkpoint
  2. Phase-level resume (interrupted before any iteration checkpoint): restarts search from beginning → identical results
  3. Iteration-level resume (interrupted after iteration checkpoint): resumes from saved tree+rates → result may differ slightly but is valid (typically
  better, since evaluator re-evaluates from a clean state)

  The iteration-level LL difference (-7220 vs -7237 in this test) occurs because the evaluator's internal CLV cache state cannot be fully serialized. The
  restored evaluator recomputes likelihoods from scratch, which can discover a different/better local optimum.